### PR TITLE
Modification to CanMessage::send to use the 3 TX buffers we have instead of always using buffer 0

### DIFF
--- a/CAN.cpp
+++ b/CAN.cpp
@@ -65,8 +65,10 @@ void CanMessage::setData (const char *data, uint8_t len)
 
 void CanMessage::send ()
 {
-	mcp2515_set_msg (0, id, data, len, extended);
-	mcp2515_request_tx (0);
+        static int i;
+        int buf = i++ % 3; // use the 3 TX buffers in a round-robin fashion
+        mcp2515_msg_set (buf, id, data, len, extended);
+        mcp2515_set_tx (buf);
 }
 
 byte CanMessage::getByteFromData()


### PR DESCRIPTION
Modifies CanMessage::send to use the 3 TX buffers we have in a round-robin fashion, rather than always using buffer zero.  Since the call is non-blocking, if we try to send multiple messages in rapid succession without doing this the second, third etc concurrent requests will fail silently.  With this update, we can handle up to 3 concurrent TX requests, and any more than that will fail silently; it might make sense in the future to provide a blocking version of the function that should always succeed.

There might also be an argument for about whether the state (namely, the 'current' buffer) should reside in CanMessage::send() itself or client code (the latter by modifying send() to take an argument for which buffer to use, perhaps defaulting to 0).
